### PR TITLE
chore: add version field to package.json (unblocks release-draft)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "xion-faucet",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Adds `"version": "0.0.0"` to `package.json` (it had no version field).

## Why

The DO-302 v12 `release.yml` `draft-release` job (adopted in #10) computes the next release from `require('./package.json').version`. With no version field that value is `undefined`, so the step throws:

```
TypeError: Cannot read properties of undefined (reading 'match')
```

This fails the `Merge PR` run on **every** push to `main` (verified on the #10 merge: `check` ✅ + `preview-testnet` ✅, but `release / draft-release` ❌). Adding a valid M.M.P version lets the draft step compute `NEXT = 0.0.1` and draft cleanly.

## Effect

Source-of-truth version only — **nothing is published or deployed**. First draft release will be `v0.0.1`. Refs DO-302.