### PR TITLE
chore(ci): DO-302 v12.3, run previews under testnet/mainnet (drop preview-* environments)

### DIFF
--- a/.github/workflows/preview-testnet.yml
+++ b/.github/workflows/preview-testnet.yml
@@ -25,7 +25,7 @@ jobs:
        github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment:
-      name: preview-testnet
+      name: testnet
       url: ${{ steps.extract.outputs.preview_url }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

DO-302 **v12.3**: point the PR preview job at the real `testnet` GitHub Environment instead of a dedicated `preview-testnet` one.

- `preview-testnet.yml`: `environment: preview-testnet` -> `testnet`

This repo is Mapping 2 (testnet-only), so there is only one preview workflow. Mirrors the reference change in [burnt-labs/cloudflare-app-template#2](https://github.com/burnt-labs/cloudflare-app-template/pull/2).

## Why

The dedicated preview environment duplicated config for no benefit. A versioned `wrangler versions upload --env testnet` produces a `*.workers.dev` URL and never flips the canonical route, so it is safe to run under the real environment.

## Safety check (this repo)

- The Nuxt build Variables (`NUXT_PUBLIC_*`, `NUXT_DISCORD_*`, etc.) are repo-level, so they resolve regardless of which environment the job runs under.
- `deploy-testnet.yml` already uses `environment: testnet`; after this change the preview job matches the deploy job.
- No required-reviewer or branch-policy rule, so previews stay automatic.

## After merge

Delete the now-orphaned `preview-testnet` GitHub Environment (Settings -> Environments).

## Behaviour

Unchanged. The testnet preview still gets a versioned-upload preview URL at PR time and at main HEAD; the URL still surfaces on the commit and open PRs; the fork-PR guard is intact.
